### PR TITLE
Add npm run watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
 	"homepage": "https://github.com/jsxtools/dom-slot-assign",
 	"repository": "https://github.com/jsxtools/dom-slot-assign.git",
 	"scripts": {
-		"build": "rollup --config rollup.config.js"
+		"build": "rollup --config rollup.config.js",
+		"watch": "rollup --config rollup.config.js --watch"
 	},
 	"devDependencies": {
 		"@rollup/plugin-typescript": "^8.3.3",


### PR DESCRIPTION
Useful when working on a project so you don't have to run `npm run build` after every change.